### PR TITLE
Replace ssh to plain git protocol

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "tests"
   ],
   "dependencies": {
-    "ttlibjs": "git@github.com:taktod/ttLibJs#dc7feeb0ec13dd365c620f5dd78e1c6f9dffc237"
+    "ttlibjs": "git://github.com/taktod/ttLibJs#dc7feeb0ec13dd365c620f5dd78e1c6f9dffc237"
   }
 }


### PR DESCRIPTION
git@ だと ssh 扱いになって鍵がないと怒られるので git:// に。
